### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 php:
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
   - nightly
 matrix:
   include:
@@ -14,8 +14,11 @@ matrix:
       env: dependencies=lowest
     - php: 7.3
       env: dependencies=highest
+    - php: 7.4
+      env: dependencies=lowest
+    - php: 7.4
+      env: dependencies=highest
   allow_failures:
-    - php: 7.4snapshot
     - php: nightly
 before_script:
   - composer self-update

--- a/src/Xpath/Functions/Text.php
+++ b/src/Xpath/Functions/Text.php
@@ -128,6 +128,12 @@ final class Text
             $flags = '';
         }
 
+        $quote = \strpos($flags, 'q');
+        if ($quote !== false) {
+            $pattern = \preg_quote($pattern, '/');
+            $flags = \substr_replace($flags, '', $quote, 1);
+        }
+
         $split = \preg_split('/'.$pattern.'/'.$flags, $input);
         if ($split === false) {
             return XsSequence::fromArray([]);

--- a/test/AbstractTestCase.php
+++ b/test/AbstractTestCase.php
@@ -9,13 +9,13 @@ abstract class AbstractTestCase extends TestCase
 {
     private $oldCwd;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->oldCwd = \getcwd();
         \chdir(__DIR__);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         \chdir($this->oldCwd);
     }

--- a/test/Integration/Xpath/TextTest.php
+++ b/test/Integration/Xpath/TextTest.php
@@ -103,6 +103,11 @@ class TextTest extends AbstractXpathTest
         $this->assertEquals('|xsl2||is||transpiled||by||genkgo/xsl|', $this->transformFile('Stubs/Xpath/Text/tokenize.xsl'));
     }
 
+    public function testTokenizeQuote()
+    {
+        $this->assertEquals('5', $this->transformFile('Stubs/Xpath/Text/tokenize-quote.xsl'));
+    }
+
     public function testInScopePrefixes()
     {
         $this->assertEquals('|xml||test2||test1|', $this->transformFile('Stubs/Xpath/Text/in-scope-prefixes.xsl'));

--- a/test/Stubs/Xpath/Text/tokenize-quote.xsl
+++ b/test/Stubs/Xpath/Text/tokenize-quote.xsl
@@ -1,0 +1,11 @@
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:param name="param1" />
+    <xsl:param name="param2" />
+
+    <xsl:output omit-xml-declaration="yes" />
+
+    <xsl:template match="/">
+        <xsl:value-of select="count(tokenize('xsl2.is.transpiled.by.genkgo/xsl', '.', 'q'))" />
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/test/Stubs/version-1.0.xsl
+++ b/test/Stubs/version-1.0.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-    <xsl:template>
+    <xsl:template name="foo">
     </xsl:template>
 
 </xsl:stylesheet>

--- a/test/Stubs/version-2.0.xsl
+++ b/test/Stubs/version-2.0.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-    <xsl:template>
+    <xsl:template name="foo">
     </xsl:template>
 
 </xsl:stylesheet>

--- a/test/Stubs/version-3.0.xsl
+++ b/test/Stubs/version-3.0.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-    <xsl:template>
+    <xsl:template name="foo">
     </xsl:template>
 
 </xsl:stylesheet>

--- a/test/Unit/XsltProcessorTest.php
+++ b/test/Unit/XsltProcessorTest.php
@@ -6,7 +6,6 @@ namespace Genkgo\Xsl\Unit;
 use DOMDocument;
 use Genkgo\Xsl\AbstractTestCase;
 use Genkgo\Xsl\Cache\NullCache;
-use Genkgo\Xsl\ProcessorFactory;
 use Genkgo\Xsl\XsltProcessor;
 
 class XsltProcessorTest extends AbstractTestCase


### PR DESCRIPTION
# Changed log
- The `php-7.4` version is available on Travis CI build.
- Removing `php-7.4` version from `allow_failures` setting o Travis CI build.
- According to the [PHPUnit fixtures reference](phpunit.readthedocs.io/en/7.5/assertions.html#assertequals), the `setUp` and `tearDown` methods are `protected`.