### PR TITLE
Fix error handler restoration

### DIFF
--- a/src/XsltProcessor.php
+++ b/src/XsltProcessor.php
@@ -77,7 +77,7 @@ final class XsltProcessor extends PhpXsltProcessor
         $transpiler = $this->createTranspiler($styleSheet);
         $useInternalErrors = \libxml_use_internal_errors(false);
 
-        $previousHandler = \set_error_handler(
+        \set_error_handler(
             function ($number, $message) {
                 throw new TransformationException(
                     'Transformation failed: ' . $message,
@@ -100,7 +100,7 @@ final class XsltProcessor extends PhpXsltProcessor
         } finally {
             \libxml_clear_errors();
             \libxml_use_internal_errors($useInternalErrors);
-            \set_error_handler($previousHandler);
+            \restore_error_handler();
         }
     }
 
@@ -204,7 +204,8 @@ final class XsltProcessor extends PhpXsltProcessor
         $streamContext = \stream_context_create($this->createStreamOptions($transpiler));
         \libxml_set_streams_context($streamContext);
 
-        return $this->createTranspiledDocument($styleSheet);
+        $transpiledDocument = $this->createTranspiledDocument($styleSheet);
+        return $transpiledDocument;
     }
 
     private function boot(): void

--- a/src/XsltProcessor.php
+++ b/src/XsltProcessor.php
@@ -115,7 +115,7 @@ final class XsltProcessor extends PhpXsltProcessor
         $transpiler = $this->createTranspiler($styleSheet);
         $useInternalErrors = \libxml_use_internal_errors(false);
 
-        $previousHandler = \set_error_handler(
+        \set_error_handler(
             function ($number, $message) {
                 throw new TransformationException(
                     'Transformation failed: ' . $message,
@@ -138,7 +138,7 @@ final class XsltProcessor extends PhpXsltProcessor
         } finally {
             \libxml_clear_errors();
             \libxml_use_internal_errors($useInternalErrors);
-            \set_error_handler($previousHandler);
+            \restore_error_handler();
         }
     }
 
@@ -153,7 +153,7 @@ final class XsltProcessor extends PhpXsltProcessor
         $transpiler = $this->createTranspiler($styleSheet);
         $useInternalErrors = \libxml_use_internal_errors(false);
 
-        $previousHandler = \set_error_handler(
+        \set_error_handler(
             function ($number, $message) {
                 throw new TransformationException(
                     'Transformation failed: ' . $message,
@@ -176,7 +176,7 @@ final class XsltProcessor extends PhpXsltProcessor
         } finally {
             \libxml_clear_errors();
             \libxml_use_internal_errors($useInternalErrors);
-            \set_error_handler($previousHandler);
+            \restore_error_handler();
         }
     }
 

--- a/src/XsltProcessor.php
+++ b/src/XsltProcessor.php
@@ -162,8 +162,7 @@ final class XsltProcessor extends PhpXsltProcessor
         $streamContext = \stream_context_create($this->createStreamOptions($transpiler));
         \libxml_set_streams_context($streamContext);
 
-        $transpiledDocument = $this->createTranspiledDocument($styleSheet);
-        return $transpiledDocument;
+        return $this->createTranspiledDocument($styleSheet);
     }
 
     private function boot(): void

--- a/test/Unit/XsltProcessorTest.php
+++ b/test/Unit/XsltProcessorTest.php
@@ -7,6 +7,7 @@ use DOMDocument;
 use Genkgo\Xsl\AbstractTestCase;
 use Genkgo\Xsl\Cache\NullCache;
 use Genkgo\Xsl\XsltProcessor;
+use PHPUnit\Framework\Error\Error;
 
 class XsltProcessorTest extends AbstractTestCase
 {
@@ -86,5 +87,28 @@ class XsltProcessorTest extends AbstractTestCase
         $processor->importStyleSheet($xslDoc);
 
         $this->assertSame('<p>test</p>', \trim($processor->transformToXML($xmlDoc)));
+    }
+
+    public function testErrorHandlerIsRestoredAfterTransformToXml(): void
+    {
+        $xmlDoc = new DOMDocument();
+        $xmlDoc->loadXML('<root/>');
+
+        $xslDoc = new DOMDocument();
+        $xslDoc->loadXML(
+            '<?xml version="1.0"?>' . PHP_EOL
+            . '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"/>'
+        );
+
+        $processor = new XsltProcessor(new NullCache());
+        $processor->importStyleSheet($xslDoc);
+
+        $processor->transformToXML($xmlDoc);
+
+        // test that after transformation the error is captured by the
+        // previous error handler and not by the one set in transformToXML
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Error captured by phpunit error handler');
+        \trigger_error('Error captured by phpunit error handler', E_USER_ERROR);
     }
 }


### PR DESCRIPTION
When call `XsltProcessor::transformToXML()` an internal error handler is set but it is not restored.

This could be because the possible missunderstand that the previous error handler can be set using `\set_error_handler()` but the correct function is `\restore_error_handler()`.

On this PR there is a first commit that probes this failure and a second commit to use the correct functions.

I have a library that depends on genkgo/xsl, I try to upgrade from version `^0.6` to `^1.0` but I can't with this issue.