### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/test/Integration/Xpath/DateTest.php
+++ b/test/Integration/Xpath/DateTest.php
@@ -7,26 +7,32 @@ class DateTest extends AbstractXpathTest
 {
     public function testCurrentTime()
     {
-        $this->assertEquals(1, \preg_match(
+        $this->assertRegExp(
             '/[0-9]{2}\:[0-9]{2}\:[0-9]{2}\+[0-9]{2}\:[0-9]{2}/',
-            $this->transformFile('Stubs/Xpath/Date/current-time.xsl')
-        ));
+            $this->transformFile(
+                'Stubs/Xpath/Date/current-time.xsl'
+            )
+        );
     }
 
     public function testCurrentDate()
     {
-        $this->assertEquals(1, \preg_match(
+        $this->assertRegExp(
             '/[0-9]{4}\-[0-9]{2}\-[0-9]{2}\+[0-9]{2}\:[0-9]{2}/',
-            $this->transformFile('Stubs/Xpath/Date/current-date.xsl')
-        ));
+            $this->transformFile(
+                'Stubs/Xpath/Date/current-date.xsl'
+            )
+        );
     }
 
     public function testCurrentDateTime()
     {
-        $this->assertEquals(1, \preg_match(
+        $this->assertRegExp(
             '/[0-9]{4}\-[0-9]{2}\-[0-9]{2}T[0-9]{2}\:[0-9]{2}\:[0-9]{2}\+[0-9]{2}\:[0-9]{2}/',
-            $this->transformFile('Stubs/Xpath/Date/current-dateTime.xsl')
-        ));
+            $this->transformFile(
+                'Stubs/Xpath/Date/current-dateTime.xsl'
+            )
+        );
     }
 
     public function testYearFromDate()

--- a/test/Integration/Xpath/SequenceTest.php
+++ b/test/Integration/Xpath/SequenceTest.php
@@ -101,7 +101,7 @@ class SequenceTest extends AbstractXpathTest
         $items = \explode(' ', $this->transformFile('Stubs/Xpath/Sequence/unordered.xsl'));
 
         foreach ($items as $item) {
-            $this->assertTrue(\in_array($item, $expected));
+            $this->assertContains($item, $expected);
         }
     }
 


### PR DESCRIPTION
# Changed log
- Using the `assertRegExp` assertion to assert result is matched with specific pattern.
- Using the `asertContains` to assert result array contains specific value.