### PR TITLE
Compatibility with PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - nightly
+  - 8.0
 matrix:
   include:
     - php: 7.2
@@ -18,10 +18,15 @@ matrix:
       env: dependencies=lowest
     - php: 7.4
       env: dependencies=highest
+    - php: 8.0
+      env: dependencies=lowest
+    - php: 8.0
+      env: dependencies=highest
   allow_failures:
-    - php: nightly
+    - php: 8.0
 before_script:
   - composer self-update
+  - if [ "$TRAVIS_PHP_VERSION" != "8.0" ]; then composer remove friendsofphp/php-cs-fixer --dev --no-interaction --no-progress --no-update; fi;
   - if [ -z "$dependencies" ]; then composer install; fi;
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest -n; fi;
   - if [ "$dependencies" = "highest" ]; then composer update -n; fi;
@@ -29,7 +34,7 @@ script:
   - ./vendor/bin/phpunit -c phpunit.xml --coverage-clover=coverage.clover
   - ./vendor/bin/phpstan analyse -l max -c .phpstan.neon src
   - ./vendor/bin/phpstan analyse -l max -c .phpstan.neon test
-  - if [ "$TRAVIS_PHP_VERSION" != "nightly" ] && [ -z "$dependencies" ]; then ./vendor/bin/php-cs-fixer fix --dry-run --verbose --config .php_cs.dist ./src ./test ; fi
+  - if [ -x "./vendor/bin/php-cs-fixer" ] && [ -z "$dependencies" ]; then ./vendor/bin/php-cs-fixer fix --dry-run --verbose --config .php_cs.dist ./src ./test ; fi
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: php
-php:
-  - 7.3
-  - 7.4
-  - 8.0
 matrix:
   include:
     - php: 7.3
@@ -17,22 +13,19 @@ matrix:
       env: dependencies=lowest
     - php: 8.0
       env: dependencies=highest
-  allow_failures:
-    - php: 8.0
 env:
   global:
     - XDEBUG_MODE=coverage
 before_script:
   - composer self-update
   - if [ "$TRAVIS_PHP_VERSION" == "8.0" ]; then composer remove friendsofphp/php-cs-fixer phpstan/phpstan phpstan/phpstan-phpunit --dev --no-interaction --no-progress --no-update; fi;
-  - if [ -z "$dependencies" ]; then composer install; fi;
-  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest -n; fi;
   - if [ "$dependencies" = "highest" ]; then composer update -n; fi;
+  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest -n; fi;
 script:
   - ./vendor/bin/phpunit -c phpunit.xml --coverage-clover=coverage.clover
   - if [ -x "./vendor/bin/phpstan"]; then ./vendor/bin/phpstan analyse -l max -c .phpstan.neon src ; fi
   - if [ -x "./vendor/bin/phpstan"]; then ./vendor/bin/phpstan analyse -l max -c .phpstan.neon test ; fi
-  - if [ -x "./vendor/bin/php-cs-fixer" ] && [ -z "$dependencies" ]; then ./vendor/bin/php-cs-fixer fix --dry-run --verbose --config .php_cs.dist ./src ./test ; fi
+  - if [ -x "./vendor/bin/php-cs-fixer" ]; then ./vendor/bin/php-cs-fixer fix --dry-run --verbose --config .php_cs.dist ./src ./test ; fi
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: php
 php:
-  - 7.2
   - 7.3
   - 7.4
   - 8.0
 matrix:
   include:
-    - php: 7.2
-      env: dependencies=lowest
-    - php: 7.2
-      env: dependencies=highest
     - php: 7.3
       env: dependencies=lowest
     - php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
       env: dependencies=highest
   allow_failures:
     - php: 8.0
+env:
+  global:
+    - XDEBUG_MODE=coverage
 before_script:
   - composer self-update
   - if [ "$TRAVIS_PHP_VERSION" != "8.0" ]; then composer remove friendsofphp/php-cs-fixer --dev --no-interaction --no-progress --no-update; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,14 @@ env:
     - XDEBUG_MODE=coverage
 before_script:
   - composer self-update
-  - if [ "$TRAVIS_PHP_VERSION" != "8.0" ]; then composer remove friendsofphp/php-cs-fixer --dev --no-interaction --no-progress --no-update; fi;
+  - if [ "$TRAVIS_PHP_VERSION" == "8.0" ]; then composer remove friendsofphp/php-cs-fixer phpstan/phpstan phpstan/phpstan-phpunit --dev --no-interaction --no-progress --no-update; fi;
   - if [ -z "$dependencies" ]; then composer install; fi;
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest -n; fi;
   - if [ "$dependencies" = "highest" ]; then composer update -n; fi;
 script:
   - ./vendor/bin/phpunit -c phpunit.xml --coverage-clover=coverage.clover
-  - ./vendor/bin/phpstan analyse -l max -c .phpstan.neon src
-  - ./vendor/bin/phpstan analyse -l max -c .phpstan.neon test
+  - if [ -x "./vendor/bin/phpstan"]; then ./vendor/bin/phpstan analyse -l max -c .phpstan.neon src ; fi
+  - if [ -x "./vendor/bin/phpstan"]; then ./vendor/bin/phpstan analyse -l max -c .phpstan.neon test ; fi
   - if [ -x "./vendor/bin/php-cs-fixer" ] && [ -z "$dependencies" ]; then ./vendor/bin/php-cs-fixer fix --dry-run --verbose --config .php_cs.dist ./src ./test ; fi
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     },
     "require-dev" : {
         "phpunit/phpunit": "^8.5.8",
-        "phpstan/phpstan": "^0.12.63",
-        "phpstan/phpstan-phpunit": "^0.12.17",
+        "phpstan/phpstan": "^0.11.20",
+        "phpstan/phpstan-phpunit": "^0.11.2",
         "friendsofphp/php-cs-fixer": "^2.9"
     },
     "autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
         "psr/simple-cache": "^1.0"
     },
     "require-dev" : {
-        "phpunit/phpunit": "^7.5.10",
-        "phpstan/phpstan": "^0.11.6",
-        "phpstan/phpstan-phpunit": "^0.11",
+        "phpunit/phpunit": "^8.5.8",
+        "phpstan/phpstan": "^0.12.63",
+        "phpstan/phpstan-phpunit": "^0.12.17",
         "friendsofphp/php-cs-fixer": "^2.9"
     },
     "autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name" : "genkgo/xsl",
     "description": "XSL 2.0 Transpiler in PHP",
     "require" : {
-        "php" : ">=7.2",
+        "php" : ">=7.3",
         "ext-json" : "*",
         "ext-libxml" : "*",
         "ext-xsl" : "*",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "phpunit/phpunit": "^8.5.8",
         "phpstan/phpstan": "^0.11.20",
         "phpstan/phpstan-phpunit": "^0.11.2",
-        "friendsofphp/php-cs-fixer": "^2.9"
+        "friendsofphp/php-cs-fixer": "^2.16.2"
     },
     "autoload" : {
         "psr-4" : {

--- a/src/Xpath/Functions/Math.php
+++ b/src/Xpath/Functions/Math.php
@@ -11,7 +11,7 @@ final class Math
      */
     public static function abs($number)
     {
-        return \abs($number);
+        return \abs((float) $number);
     }
 
     /**
@@ -20,7 +20,7 @@ final class Math
      */
     public static function ceiling($number)
     {
-        return \ceil($number);
+        return \ceil((float) $number);
     }
 
     /**
@@ -29,7 +29,7 @@ final class Math
      */
     public static function floor($number)
     {
-        return \floor($number);
+        return \floor((float) $number);
     }
 
     /**
@@ -38,7 +38,7 @@ final class Math
      */
     public static function round($number)
     {
-        return \round($number);
+        return \round((float) $number);
     }
 
     /**
@@ -48,6 +48,6 @@ final class Math
      */
     public static function roundHalfToEven($number, $precision = 0)
     {
-        return \round($number, (int)$precision, PHP_ROUND_HALF_EVEN);
+        return \round((float) $number, (int)$precision, PHP_ROUND_HALF_EVEN);
     }
 }

--- a/src/XsltProcessor.php
+++ b/src/XsltProcessor.php
@@ -92,9 +92,10 @@ final class XsltProcessor extends PhpXsltProcessor
 
     /**
      * @param \DOMNode $doc
+     * @param string|null $returnClass
      * @return \DOMDocument
      */
-    public function transformToDoc($doc):? \DOMDocument
+    public function transformToDoc($doc, ?string $returnClass = null):? \DOMDocument
     {
         $styleSheet = $this->styleSheetToDomDocument();
 

--- a/test/AbstractTestCase.php
+++ b/test/AbstractTestCase.php
@@ -9,13 +9,13 @@ abstract class AbstractTestCase extends TestCase
 {
     private $oldCwd;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->oldCwd = \getcwd();
         \chdir(__DIR__);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         \chdir($this->oldCwd);
     }

--- a/test/Integration/Schema/XsDateTest.php
+++ b/test/Integration/Schema/XsDateTest.php
@@ -11,7 +11,7 @@ class XsDateTest extends AbstractSchemaTest
     {
         $result = $this->transformFile('Stubs/Schema/date.xsl');
 
-        $this->assertContains('1995-05-10+00:00', $result);
+        $this->assertStringContainsString('1995-05-10+00:00', $result);
     }
 
     public function testWrongConstructor()

--- a/test/Integration/Schema/XsDateTimeTest.php
+++ b/test/Integration/Schema/XsDateTimeTest.php
@@ -11,7 +11,7 @@ class XsDateTimeTest extends AbstractSchemaTest
     {
         $result = $this->transformFile('Stubs/Schema/dateTime.xsl');
 
-        $this->assertContains('1995-05-10T00:00:00+00:00', $result);
+        $this->assertStringContainsString('1995-05-10T00:00:00+00:00', $result);
     }
 
     public function testWrongConstructor()

--- a/test/Integration/Schema/XsTimeTest.php
+++ b/test/Integration/Schema/XsTimeTest.php
@@ -11,7 +11,7 @@ class XsTimeTest extends AbstractSchemaTest
     {
         $result = $this->transformFile('Stubs/Schema/time.xsl');
 
-        $this->assertContains('12:00:00', $result);
+        $this->assertStringContainsString('12:00:00', $result);
     }
 
     public function testWrongConstructor()

--- a/test/Integration/Xpath/ForLoopTest.php
+++ b/test/Integration/Xpath/ForLoopTest.php
@@ -8,13 +8,13 @@ class ForLoopTest extends AbstractXpathTest
     public function testSimple()
     {
         $result = $this->transformFile('Stubs/Xpath/ForLoop/simple.xsl');
-        $this->assertContains('1 2 3 4 5 6 7 8 9 10', $result);
+        $this->assertStringContainsString('1 2 3 4 5 6 7 8 9 10', $result);
     }
 
     public function testForEach()
     {
         $result = $this->transformFile('Stubs/Xpath/ForLoop/for-each.xsl');
-        $this->assertContains('12345678910', $result);
+        $this->assertStringContainsString('12345678910', $result);
     }
 
     public function testElements()

--- a/test/Integration/Xpath/SequenceTest.php
+++ b/test/Integration/Xpath/SequenceTest.php
@@ -8,19 +8,19 @@ class SequenceTest extends AbstractXpathTest
     public function testConstructorString()
     {
         $result = $this->transformFile('Stubs/Xpath/Sequence/constructor-string.xsl');
-        $this->assertContains('a b c', $result);
+        $this->assertStringContainsString('a b c', $result);
     }
 
     public function testMultipleParenthesis()
     {
         $result = $this->transformFile('Stubs/Xpath/Sequence/constructor-multiple-parenthesis.xsl');
-        $this->assertContains('a b c', $result);
+        $this->assertStringContainsString('a b c', $result);
     }
 
     public function testConstructorInteger()
     {
         $result = $this->transformFile('Stubs/Xpath/Sequence/constructor-integer.xsl');
-        $this->assertContains('1 2 3', $result);
+        $this->assertStringContainsString('1 2 3', $result);
     }
 
     public function testReverse()

--- a/test/Integration/Xsl/AttributeValueTemplatesTest.php
+++ b/test/Integration/Xsl/AttributeValueTemplatesTest.php
@@ -11,21 +11,21 @@ final class AttributeValueTemplatesTest extends AbstractXslTest
     {
         $result = $this->transformFile('Stubs/Xsl/AttributeValueTemplates/single-expression.xsl');
 
-        $this->assertContains('#Ladyland', $result);
+        $this->assertStringContainsString('#Ladyland', $result);
     }
 
     public function testEscaping()
     {
         $result = $this->transformFile('Stubs/Xsl/AttributeValueTemplates/escaping.xsl');
 
-        $this->assertContains('#{substring-after(title, \'Electric \')}', $result);
+        $this->assertStringContainsString('#{substring-after(title, \'Electric \')}', $result);
     }
 
     public function testMultipleExpression()
     {
         $result = $this->transformFile('Stubs/Xsl/AttributeValueTemplates/multiple-expressions.xsl');
 
-        $this->assertContains('Ladyland/Jimi Hendrix', $result);
+        $this->assertStringContainsString('Ladyland/Jimi Hendrix', $result);
     }
 
     public function testNotEscapedNotClosed()
@@ -44,27 +44,27 @@ final class AttributeValueTemplatesTest extends AbstractXslTest
     {
         $result = $this->transformFile('Stubs/Xsl/AttributeValueTemplates/expression-with-content.xsl');
 
-        $this->assertContains('#Ladyland#', $result);
+        $this->assertStringContainsString('#Ladyland#', $result);
     }
 
     public function testExpressionAndEscaping()
     {
         $result = $this->transformFile('Stubs/Xsl/AttributeValueTemplates/expression-and-escaping.xsl');
 
-        $this->assertContains('#Ladyland}', $result);
+        $this->assertStringContainsString('#Ladyland}', $result);
     }
 
     public function testAmpersandEscaped()
     {
         $result = $this->transformFile('Stubs/Xsl/AttributeValueTemplates/ampersand-escaped.xsl');
 
-        $this->assertContains('link?x=y&amp;a=b', $result);
+        $this->assertStringContainsString('link?x=y&amp;a=b', $result);
     }
 
     public function testAmpersandGreaterThan()
     {
         $result = $this->transformFile('Stubs/Xsl/AttributeValueTemplates/ampersand-greater-than.xsl');
 
-        $this->assertContains('link?x=y&amp;year=1997', $result);
+        $this->assertStringContainsString('link?x=y&amp;year=1997', $result);
     }
 }

--- a/test/Integration/Xsl/ExpandTextTest.php
+++ b/test/Integration/Xsl/ExpandTextTest.php
@@ -15,7 +15,7 @@ class ExpandTextTest extends AbstractXslTest
 
     public function testExpandTextOverwrite()
     {
-        $this->assertContains(
+        $this->assertStringContainsString(
             '{artist}',
             $this->transformFile('Stubs/Xsl/TextValueTemplates/expand-text-overwrite.xsl')
         );

--- a/test/Integration/Xsl/MatchTest.php
+++ b/test/Integration/Xsl/MatchTest.php
@@ -7,6 +7,6 @@ final class MatchTest extends AbstractXslTest
 {
     public function testMatch()
     {
-        $this->assertContains('matched', $this->transformFile('Stubs/Xsl/match.xsl'));
+        $this->assertStringContainsString('matched', $this->transformFile('Stubs/Xsl/match.xsl'));
     }
 }

--- a/test/Integration/Xsl/ValueOfTest.php
+++ b/test/Integration/Xsl/ValueOfTest.php
@@ -17,7 +17,7 @@ class ValueOfTest extends AbstractXslTest
 
     public function testSequenceSingleItem()
     {
-        $this->assertNotContains(',', $this->transformFile('Stubs/Xsl/ValueOf/sequence-single.xsl'));
+        $this->assertStringNotContainsString(',', $this->transformFile('Stubs/Xsl/ValueOf/sequence-single.xsl'));
     }
 
     public function testWithoutSeparator()


### PR DESCRIPTION
PHPUnit is upgraded since this library supports PHP >= 7.2 and PHPUnit 8 supports from 7.2 until 8.0

- Fix XSLTProcessor::transformToDoc signature to match with PHP XSLTProcessor.
- Fix Math functions by casting to floats.
- Update tests to work with PHPUnit 8.
- Travis-CI: Fixed compatibility with XDebug 3.0.
- Travis-CI: Due compatibility issues with PHP 8.0, do not install or test php-cs-fixer and phpstan.

**Important:** One pending task (that requires a different PR) is to upgrade PHPStan from version 0.11 to version 0.12.